### PR TITLE
Mark Utxos as Stake Contract over API

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -266,6 +266,7 @@ type Utxo struct {
 	Address       string  `json:"address,omitempty"`
 	Path          string  `json:"path,omitempty"`
 	Locktime      uint32  `json:"lockTime,omitempty"`
+	StakeContract bool  `json:"stake_contract"`
 }
 
 // Utxos is array of Utxo

--- a/api/worker.go
+++ b/api/worker.go
@@ -847,11 +847,22 @@ func (w *Worker) getAddrDescUtxo(addrDesc bchain.AddressDescriptor, ba *db.AddrB
 							// report only outpoints that are not spent in mempool
 							_, e := spentInMempool[bchainTx.Txid+strconv.Itoa(i)]
 							if !e {
+								stakeContract := false
+								if len(bchainTx.Vout[i].ScriptPubKey.Addresses) > 1 {
+									for _, addrStr := range bchainTx.Vout[i].ScriptPubKey.Addresses {
+										prefix := addrStr[0:1]
+										if prefix == "S" {
+											stakeContract = true
+										}
+									}
+									stakeContract = true
+								}
 								r = append(r, Utxo{
 									Txid:      bchainTx.Txid,
 									Vout:      int32(i),
 									AmountSat: (*Amount)(&vout.ValueSat),
 									Locktime:  bchainTx.LockTime,
+									StakeContract: stakeContract,
 								})
 							}
 						}
@@ -884,6 +895,23 @@ func (w *Worker) getAddrDescUtxo(addrDesc bchain.AddressDescriptor, ba *db.AddrB
 				if err != nil {
 					return nil, err
 				}
+				stakeContract := false
+				ta, err := w.db.GetTxAddresses(txid)
+				if err != nil {
+					return nil, err
+				}
+				addr, _, err := ta.Outputs[utxo.Vout].Addresses(w.chainParser)
+				if err != nil {
+					return nil, err
+				}
+				if len(addr) > 1 {
+					for _, addrStr := range addr {
+						prefix := addrStr[0:1]
+						if prefix == "S" {
+							stakeContract = true
+						}
+					}
+				}
 				_, e := spentInMempool[txid+strconv.Itoa(int(utxo.Vout))]
 				if !e {
 					r = append(r, Utxo{
@@ -892,6 +920,7 @@ func (w *Worker) getAddrDescUtxo(addrDesc bchain.AddressDescriptor, ba *db.AddrB
 						AmountSat:     (*Amount)(&utxo.ValueSat),
 						Height:        int(utxo.Height),
 						Confirmations: bestheight - int(utxo.Height) + 1,
+						StakeContract: stakeContract,
 					})
 				}
 				checksum.Sub(&checksum, &utxo.ValueSat)


### PR DESCRIPTION
Hello. 
I have build a mobile wallet that is able to use the Cold Stake functionality and I want to port it to PIVX, this API seems to be the better use for running a PIVX node. 

Now, the API requires to mark the utxos as cold stake for the lightwallet to know how to spend them.